### PR TITLE
Remove grammatically invalid "a"

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -18,7 +18,7 @@ A dictionary of Free and Open Source software terms
    free, as in [Free Software](#Free_Software), and requiring all
    derivative work to be free. Copyleft is usually divided in to [Weak
    Copyleft](#Weak_Copyleft) and [Strong
-   Copyleft](#Strong_Copyleft). Copyleft is implemented using a [Free
+   Copyleft](#Strong_Copyleft). Copyleft is implemented using [Free
    Software](#Free_Software) [Licenses](#License), e.g. the
    [GPL](#GPL) family. See also [Copyright](#Copyright)
 


### PR DESCRIPTION
It should either be:

"Copyleft is implemented using a Free Software License, ..."

or

"Copyleft is implemented using Free Software Licenses, ..."

and since there are multiple, removing the "a" seems more appropriate than removing the trailing s on "Licenses".